### PR TITLE
document 17k char limit, remove pages file warning

### DIFF
--- a/ResumeParsing.md
+++ b/ResumeParsing.md
@@ -32,9 +32,9 @@ Input Data
 
 Input should be provided in the POST request body, and content type should be either JSON or Form Vars (xml is not accepted)
 
-document: We accept .doc, .docx, .pdf, .rtf, .txt, .odt, and .wps documents given in a BASE64 encoded string.
+document: We accept .doc, .docx, .pdf, .rtf, .txt, .odt, and .wps documents given in a BASE64 encoded string. Documents may not exceed 17,000 characters in length; those that do will incur an HTTP 413 Request-Entity Too Large error. This character limit includes spaces, but not include tabs or newlines.
 
-   *** PLEASE NOTE THAT .PAGES FILES ARE NO LONGER ACCEPTED BY THE RESUME PARSING SERVICE! ***
+Note that image files (including scanned resumes) are not supported at this time.
 
 language: ISO 639-1 language code (i.e. en, en-gb, es-419), this is used if a service is not specified to determine the parsing service we wish to use. (optional)
 


### PR DESCRIPTION
2 months is long enough, shouldn't need to keep that .pages warning around forever. also added a note about image files
