### PR TITLE
removing job location city

### DIFF
--- a/JobParseAndNormalize.md
+++ b/JobParseAndNormalize.md
@@ -67,7 +67,6 @@ The following parameters may be supplied in the query string (for HTTP GET) or f
         "address": string,
         "region": string,
         "country": string,
-        "city": string
       },
       "salary": {
         "from": string,


### PR DESCRIPTION
Company location and job location share a common response object. In practice though, job location city will never be returned because their is no city on the corresponding tk response fields.